### PR TITLE
Fix zone statistics rendering

### DIFF
--- a/app.html
+++ b/app.html
@@ -128,6 +128,7 @@
     </footer>
   </div>
 
+  <script src="zones-kpi.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -41,7 +41,9 @@
         "app.html",
         "app.js",
         "app.css",
-        "page-bridge.js"
+        "page-bridge.js",
+        "zones-kpi.js",
+        "zones-kpi.css"
       ],
       "matches": [
         "https://cmp.wildberries.ru/*"

--- a/zones-kpi.css
+++ b/zones-kpi.css
@@ -1,7 +1,7 @@
 
 /* zones-kpi.css — stack zone cards vertically with pleasant spacing */
-.zones {
-  display: grid !important;
+.zone-grid {
+  display: grid;
   grid-template-columns: 1fr;
   gap: 12px;
   margin: 12px 8px 16px;

--- a/zones-kpi.js
+++ b/zones-kpi.js
@@ -200,7 +200,7 @@
       res.shelves = sh;
 
       // render
-      setTexts('z-overall', res.overall);
+      setTexts('z-total', res.overall);
       setTexts('z-search', res.search);
       setTexts('z-catalog', res.catalog);
       setTexts('z-shelves', res.shelves);


### PR DESCRIPTION
## Summary
- load zones-kpi script and resources to compute fullstat KPIs
- display summary, search, catalog and shelves stats with correct IDs
- stack zone cards vertically for clearer layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e608d3348331aa6021d6fe68820c